### PR TITLE
fix(script): 修复整页刷新后控制面板不显示的问题

### DIFF
--- a/src/linuxdo-automation.user.js
+++ b/src/linuxdo-automation.user.js
@@ -204,8 +204,19 @@
     return Math.floor(Math.random() * (max - min + 1)) + min;
   }
 
-  function isLoggedIn() {
-    return document.querySelector('#current-user') !== null;
+  // 登录状态三态检测：true=已登录，false=未登录，null=无法判定（页面未就绪或 Cloudflare 挑战页）
+  // 优先读取 #data-preloaded（服务端直出，脚本注入时必然存在），
+  // 避免与 Ember 渲染 #current-user 竞速导致误判（脚本注入时 header 尚未渲染）
+  function getLoginState() {
+    const preloaded = document.querySelector('#data-preloaded');
+    if (preloaded) {
+      try {
+        return 'currentUser' in JSON.parse(preloaded.dataset.preloaded);
+      } catch (e) {
+        // 解析失败，回退到 DOM 检测
+      }
+    }
+    return document.querySelector('#current-user') !== null ? true : null;
   }
 
   function getPageType() {
@@ -1008,8 +1019,21 @@
       }
     }
 
-    setup() {
-      if (!isLoggedIn()) {
+    setup(retryCount = 0) {
+      const loginState = getLoginState();
+
+      // 无法判定登录状态（Ember 未渲染完成或 Cloudflare 挑战页）：轮询等待，最多 10 秒
+      // 挑战页通过后会整页跳转、脚本重新注入，因此超时放弃是安全的
+      if (loginState === null) {
+        if (retryCount < 20) {
+          setTimeout(() => this.setup(retryCount + 1), 500);
+        } else {
+          log('无法检测登录状态，跳过初始化');
+        }
+        return;
+      }
+
+      if (loginState === false) {
         log('请先登录 Linux.do');
         return;
       }


### PR DESCRIPTION
## 问题
#3 

浏览完一个帖子（脚本整页跳转回列表）或手动刷新页面后，控制面板浮窗不再显示；禁用/启用脚本无效，只有删除重装后第一次刷新才偶然出现。

## 根因

登录检测与 Ember 渲染存在竞速条件：

- Linux.do（Discourse）是客户端渲染的 Ember SPA，`#current-user` 由 Ember 在 DOMContentLoaded 之后约 300ms+ 才渲染
- 脚本以 `@run-at document-idle` 注入，此时 `#current-user` 尚不存在，`isLoggedIn()` 误判为未登录
- `setup()` 静默 `return`：浮窗不创建，`auto_running` 自动恢复也不执行
- 「删除重装后第一次有浮窗」是 Tampermonkey 冷启动注入偏慢、恰好晚于 Ember 渲染的时序巧合，与存储无关

## 修复

- 新增 `getLoginState()` 三态检测：优先读取 `#data-preloaded`（服务端直出，注入时必然存在，登录时其 JSON 含 `currentUser` 键），彻底消除竞速；`#current-user` 仅作回退
- `setup()` 对无法判定的状态（如 Cloudflare 挑战页）每 500ms 轮询重试，最多 10 秒，不再静默失败

## 验证

- [x] `node --check` 语法检查通过
- [x] 真实浏览器实测：DOMContentLoaded 时刻 `#current-user` 不存在（旧逻辑必然误判）、`#data-preloaded` 已存在（新逻辑可正确判定）
- [x] 已登录环境下多次整页刷新，确认浮窗稳定显示